### PR TITLE
85923 Fix to invalid backslash character pair syntax warning in get_l…

### DIFF
--- a/src/range_repair.py
+++ b/src/range_repair.py
@@ -130,7 +130,7 @@ class TokenContainer:
         # This is a really well-specified value.  If the format of the
         # output of 'nodetool gossipinfo' changes, this will have to be
         # revisited.
-        search_regex = "DC(?::\d+)?:{datacenter}".format(datacenter=self.options.datacenter)
+        search_regex = r"DC(?::\d+)?:{datacenter}".format(datacenter=self.options.datacenter)
         for paragraph in stdout.split("/"):
             if not re.search(search_regex, paragraph):
                 continue


### PR DESCRIPTION
…ocal_nodes to use raw string.